### PR TITLE
Add Confluence user logging helper

### DIFF
--- a/config_docs.md
+++ b/config_docs.md
@@ -72,7 +72,7 @@ This object contains global settings that apply to the entire dashboard.
 ### `trueValues`
 *   **Type:** `Array<String>`
 *   **Description:** A list of strings that should be interpreted as "true" when performing boolean checks (e.g., for `booleanTrue` / `booleanFalse` filters or for `isTruthy` checks in icon styling). Comparisons are case-insensitive.
-*   **Example:** `"trueValues": ["TRUE", "true", "Yes", "1", "Cursed", "Active", "Done", "âœ“"]`
+*   **Example:** `"trueValues": ["TRUE", "true", "Yes", "1", "Cursed", "Active", "Done", "✓"]`
 
 ### `csvDelimiter`
 *   **Type:** `String`
@@ -88,7 +88,7 @@ This object contains global settings that apply to the entire dashboard.
 
 ### `linkColumns`
 *   **Type:** `Array<String>`
-*   **Description:** A list of column header names whose values should be rendered as clickable links (typically with a ðŸ”— icon).
+*   **Description:** A list of column header names whose values should be rendered as clickable links (typically with a 🔗 icon).
     *   If the cell value is a full URL (starts with `http://` or `https://`), it will be used directly.
     *   If the cell value is an ID, and a corresponding prefix is defined in `linkPrefixes`, a full URL will be constructed.
 *   **Example:** `"linkColumns": ["WikiLink", "ItemID", "ReferenceDocument"]`

--- a/csv_editor/js/confluence_attachment.js
+++ b/csv_editor/js/confluence_attachment.js
@@ -6,6 +6,13 @@ function confluenceAvailable() {
            AJS.Meta && typeof AJS.Meta.get === 'function';
 }
 
+function getConfluenceUser() {
+    if (!confluenceAvailable()) return null;
+    const id = AJS.params?.remoteUser;
+    const name = AJS.params?.userDisplayName;
+    return id ? { id: String(id).toUpperCase(), name } : null;
+}
+
 async function saveOrUpdateConfluenceAttachment(fileName, fileContent) {
     return new Promise(async (resolve, reject) => {
         if (!confluenceAvailable()) {

--- a/csv_editor/js/editor_app.js
+++ b/csv_editor/js/editor_app.js
@@ -414,7 +414,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             const effectiveHeadersForPartitionCheck = editorCfg.columns.map(c => c.name);
             const configForPartitionCheck = {
                 generalSettings: {
-                    trueValues: viewerCfg?.generalSettings?.trueValues || ["true", "yes", "1", "y", "x", "on", "âœ“"]
+                    trueValues: viewerCfg?.generalSettings?.trueValues || ["true", "yes", "1", "y", "x", "on", "✓"]
                 },
                 csvHeaders: effectiveHeadersForPartitionCheck
             };
@@ -808,7 +808,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         const configForCheck = {
             csvHeaders: headersForCheck,
             generalSettings: {
-                trueValues: viewerCfg?.generalSettings?.trueValues || ["true", "yes", "1", "y", "x", "on", "âœ“"]
+                trueValues: viewerCfg?.generalSettings?.trueValues || ["true", "yes", "1", "y", "x", "on", "✓"]
             }
         };
 
@@ -1070,7 +1070,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             // Construct Markdown changelog content using the new timestamp format
             let combinedLogContent = `## Changes Recorded: ${newChangesTimestampForContent}\n\n`;
-            const user = (typeof getConfluenceUser === 'function') ? getConfluenceUser() : null;
+            const user = getConfluenceUser();
             if (user) {
                 combinedLogContent += `Editor - User ID: ${user.id} | UserName: ${user.name}\n\n`;
             } else {
@@ -1112,7 +1112,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (initialCsvData.length > 0) changesDigest = generateChangeDigestOnDemand();
 
                 let combined = `## Changes Recorded: ${newChangesStamp}\n\n` + changesDigest + "\n\n";
-                const user = (typeof getConfluenceUser === 'function') ? getConfluenceUser() : null;
+                const user = getConfluenceUser();
                 if (user) {
                     combined += `Editor - User ID: ${user.id} | UserName: ${user.name}\n\n`;
                 } else {
@@ -1158,7 +1158,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             // Construct Markdown changelog content for modal
             let combinedDigestText = `## Changes Recorded: ${newChangesTimestampForContent}\n\n`;
-            const user = (typeof getConfluenceUser === 'function') ? getConfluenceUser() : null;
+            const user = getConfluenceUser();
             if (user) {
                 combinedDigestText += `Editor - User ID: ${user.id} | UserName: ${user.name}\n\n`;
             } else {

--- a/csv_editor/js/editor_app.js
+++ b/csv_editor/js/editor_app.js
@@ -1070,7 +1070,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             // Construct Markdown changelog content using the new timestamp format
             let combinedLogContent = `## Changes Recorded: ${newChangesTimestampForContent}\n\n`;
-            const user = getConfluenceUser();
+            const user = (typeof getConfluenceUser === 'function') ? getConfluenceUser() : null;
             if (user) {
                 combinedLogContent += `Editor - User ID: ${user.id} | UserName: ${user.name}\n\n`;
             } else {
@@ -1112,7 +1112,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 if (initialCsvData.length > 0) changesDigest = generateChangeDigestOnDemand();
 
                 let combined = `## Changes Recorded: ${newChangesStamp}\n\n` + changesDigest + "\n\n";
-                const user = getConfluenceUser();
+                const user = (typeof getConfluenceUser === 'function') ? getConfluenceUser() : null;
                 if (user) {
                     combined += `Editor - User ID: ${user.id} | UserName: ${user.name}\n\n`;
                 } else {
@@ -1158,7 +1158,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             // Construct Markdown changelog content for modal
             let combinedDigestText = `## Changes Recorded: ${newChangesTimestampForContent}\n\n`;
-            const user = getConfluenceUser();
+            const user = (typeof getConfluenceUser === 'function') ? getConfluenceUser() : null;
             if (user) {
                 combinedDigestText += `Editor - User ID: ${user.id} | UserName: ${user.name}\n\n`;
             } else {

--- a/csv_editor/js/editor_app.js
+++ b/csv_editor/js/editor_app.js
@@ -1070,6 +1070,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             // Construct Markdown changelog content using the new timestamp format
             let combinedLogContent = `## Changes Recorded: ${newChangesTimestampForContent}\n\n`;
+            const user = getConfluenceUser();
+            if (user) {
+                combinedLogContent += `Editor - User ID: ${user.id} | UserName: ${user.name}\n\n`;
+            } else {
+                combinedLogContent += `Editor - User ID : Not available outside of confluence\n\n`;
+            }
             combinedLogContent += newChangesDigest + "\n\n";
             combinedLogContent += "---\n\n";
 
@@ -1105,7 +1111,14 @@ document.addEventListener('DOMContentLoaded', async () => {
                 let changesDigest = '*No new changes detected since last CSV load.*\n';
                 if (initialCsvData.length > 0) changesDigest = generateChangeDigestOnDemand();
 
-                let combined = `## Changes Recorded: ${newChangesStamp}\n\n` + changesDigest + "\n\n---\n\n";
+                let combined = `## Changes Recorded: ${newChangesStamp}\n\n` + changesDigest + "\n\n";
+                const user = getConfluenceUser();
+                if (user) {
+                    combined += `Editor - User ID: ${user.id} | UserName: ${user.name}\n\n`;
+                } else {
+                    combined += `Editor - User ID : Not available outside of confluence\n\n`;
+                }
+                combined += "---\n\n";
                 if (cachedCumulativeLogContent !== null) {
                     combined += cachedCumulativeLogContent;
                 } else if (cfg.cumulativeLogUrl) {
@@ -1145,6 +1158,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 
             // Construct Markdown changelog content for modal
             let combinedDigestText = `## Changes Recorded: ${newChangesTimestampForContent}\n\n`;
+            const user = getConfluenceUser();
+            if (user) {
+                combinedDigestText += `Editor - User ID: ${user.id} | UserName: ${user.name}\n\n`;
+            } else {
+                combinedDigestText += `Editor - User ID : Not available outside of confluence\n\n`;
+            }
             combinedDigestText += newChangesDigest + "\n\n";
             combinedDigestText += "---\n\n";
 

--- a/csv_editor/js/editor_data_grid.js
+++ b/csv_editor/js/editor_data_grid.js
@@ -188,7 +188,7 @@ function getStyledCellDisplay(cellValue, colDef) {
     if (isLinkColInViewer && colDef.type !== 'checkbox') {
         const urlValueStr = String(cellValue ?? '');
         if (urlValueStr.trim() !== '') {
-            return `<span class="cell-url-display-span" title="${urlValueStr}">ðŸ”—${urlValueStr}</span>`;
+            return `<span class="cell-url-display-span" title="${urlValueStr}">🔗${urlValueStr}</span>`;
         } else { return ''; }
     }
 

--- a/js/renderers/renderer-shared.js
+++ b/js/renderers/renderer-shared.js
@@ -140,7 +140,7 @@ function generateIndicatorsHTML(row, columnName, globalConfig, fullDataset) {
             }
 
             if (fullUrl) {
-                generatedHtmlArray.push(`<a href="${fullUrl}" target="_blank" rel="noopener noreferrer" title="${linkTitle}" class="card-link-icon">ðŸ”—</a>`);
+                generatedHtmlArray.push(`<a href="${fullUrl}" target="_blank" rel="noopener noreferrer" title="${linkTitle}" class="card-link-icon">🔗</a>`);
             }
         });
         return generatedHtmlArray;

--- a/js/renderers/renderer-table.js
+++ b/js/renderers/renderer-table.js
@@ -110,7 +110,7 @@ function renderTable(filteredData, tabConfig, globalConfig, targetElement, showM
                             fullUrl = cellValue;
                         }
                         if (fullUrl) {
-                            linksHtmlArray.push(`<a href="${fullUrl}" target="_blank" rel="noopener noreferrer" title="Open Link: ${fullUrl}" class="table-link-icon">ðŸ”—</a>`);
+                            linksHtmlArray.push(`<a href="${fullUrl}" target="_blank" rel="noopener noreferrer" title="Open Link: ${fullUrl}" class="table-link-icon">🔗</a>`);
                             linksTitleArray.push(`Open Link: ${fullUrl}`);
                         } else if (cellValue) {
                             linksHtmlArray.push(`<span class="cell-text">${cellValue}</span>`);


### PR DESCRIPTION
## Summary
- add `getConfluenceUser` helper
- log Confluence user info when exporting logs, uploading to Confluence, or viewing changes

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684464d7bb808328b9b09c672c6d8548