### PR TITLE
Allow specifying target page for Confluence upload

### DIFF
--- a/csv_editor/editor_config_example.js
+++ b/csv_editor/editor_config_example.js
@@ -22,7 +22,9 @@ window.editorConfig = {
     "confluenceAttachmentSettings": {
         "enabled": false,
         "csvAttachmentName": "EditorData.csv",
-        "changelogAttachmentName": "EditorChangelog.md"
+        "csvAttachmentPageId": null,
+        "changelogAttachmentName": "EditorChangelog.md",
+        "changelogAttachmentPageId": null
     },
 
     "editorDisplaySettings": {

--- a/csv_editor/js/confluence_attachment.js
+++ b/csv_editor/js/confluence_attachment.js
@@ -13,14 +13,14 @@ function getConfluenceUser() {
     return id ? { id: String(id).toUpperCase(), name } : null;
 }
 
-async function saveOrUpdateConfluenceAttachment(fileName, fileContent) {
+async function saveOrUpdateConfluenceAttachment(fileName, fileContent, targetPageId = null) {
     return new Promise(async (resolve, reject) => {
         if (!confluenceAvailable()) {
             return reject({ message: 'Confluence AJS object not available.' });
         }
-        const pageId = AJS.Meta.get('page-id');
+        const effectivePageId = targetPageId || AJS.Meta.get('page-id');
         const contextPath = AJS.contextPath();
-        if (!pageId) return reject({ message: 'Error: Could not determine Page ID.' });
+        if (!effectivePageId) return reject({ message: 'Error: Could not determine Page ID.' });
 
         const mimeType = fileName.endsWith('.csv') ? 'text/csv'
             : (fileName.endsWith('.md') ? 'text/markdown' : 'text/plain');
@@ -29,14 +29,14 @@ async function saveOrUpdateConfluenceAttachment(fileName, fileContent) {
         formData.append('comment', `File updated programmatically on ${new Date().toLocaleDateString()}`);
         formData.append('minorEdit', 'true');
 
-        const checkUrl = `${contextPath}/rest/api/content/${pageId}/child/attachment?filename=${encodeURIComponent(fileName)}`;
+        const checkUrl = `${contextPath}/rest/api/content/${effectivePageId}/child/attachment?filename=${encodeURIComponent(fileName)}`;
         try {
             const checkResp = await fetch(checkUrl, { credentials: 'same-origin' });
             if (checkResp.ok) {
                 const respData = await checkResp.json();
                 const attachmentId = (respData.results && respData.results.length > 0) ? respData.results[0].id : null;
                 if (attachmentId) {
-                    const updateUrl = `${contextPath}/rest/api/content/${pageId}/child/attachment/${attachmentId}/data`;
+                    const updateUrl = `${contextPath}/rest/api/content/${effectivePageId}/child/attachment/${attachmentId}/data`;
                     const upResp = await fetch(updateUrl, {
                         method: 'POST',
                         body: formData,
@@ -46,10 +46,10 @@ async function saveOrUpdateConfluenceAttachment(fileName, fileContent) {
                     if (!upResp.ok) throw upResp;
                     return resolve(await upResp.json());
                 } else {
-                    return resolve(await _createNewAttachment(pageId, contextPath, formData));
+                    return resolve(await _createNewAttachment(effectivePageId, contextPath, formData));
                 }
             } else if (checkResp.status === 404) {
-                return resolve(await _createNewAttachment(pageId, contextPath, formData));
+                return resolve(await _createNewAttachment(effectivePageId, contextPath, formData));
             } else {
                 throw checkResp;
             }

--- a/csv_editor/js/editor_app.js
+++ b/csv_editor/js/editor_app.js
@@ -1104,6 +1104,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 const csvOptions = cfg.csvOutputOptions || {};
                 const csvString = generateCsvForExport(csvDataMain, cfg.columns, csvOptions);
                 const csvName = cfg.confluenceAttachmentSettings?.csvAttachmentName || 'editor_data.csv';
+                const csvPageId = cfg.confluenceAttachmentSettings?.csvAttachmentPageId || null;
 
                 const now = new Date();
                 const ts = getFormattedTimestampsForLog(now);
@@ -1125,9 +1126,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                     combined += `*Note: Previous cumulative log from ${cfg.cumulativeLogUrl} could not be loaded.*\n`;
                 }
                 const logName = cfg.confluenceAttachmentSettings?.changelogAttachmentName || 'changelog.md';
+                const logPageId = cfg.confluenceAttachmentSettings?.changelogAttachmentPageId || null;
 
-                await saveOrUpdateConfluenceAttachment(csvName, csvString);
-                await saveOrUpdateConfluenceAttachment(logName, combined);
+                await saveOrUpdateConfluenceAttachment(csvName, csvString, csvPageId);
+                await saveOrUpdateConfluenceAttachment(logName, combined, logPageId);
                 updateEditorStatus('Attachments saved to Confluence.');
             } catch (err) {
                 console.error('Confluence upload failed', err);


### PR DESCRIPTION
## Summary
- allow uploading attachments to a different Confluence page
- plumb target page settings through editor config and calls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68448149dd1c832891bb56428e231427