### PR TITLE
Implement partition logic for hierarchy view

### DIFF
--- a/css/view-table.css
+++ b/css/view-table.css
@@ -105,4 +105,9 @@
 #cdg-dashboard-wrapper .view-container[data-view-type="table-hierarchy"] td[style*="text-align: center"] .cell-content-wrapper {
     justify-content: center;
 }
+
+/* Separator row used when partitioning hierarchical data */
+#cdg-dashboard-wrapper .view-container[data-view-type="table-hierarchy"] tbody tr.table-partition-separator td {
+    border-top: 3px solid #555;
+}
 /* --- END OF FILE css/view-table.css --- */


### PR DESCRIPTION
## Summary
- support partition filtering in hierarchical table renderer
- show separator before partitioned rows in hierarchy view
- style separator rows in hierarchy tables

## Testing
- `pre-commit` *(fails: not configured)*

------
https://chatgpt.com/codex/tasks/task_e_684558e9f8b48328a915c1ed386c69b1